### PR TITLE
CSSOM

### DIFF
--- a/playground/cssom/index.html
+++ b/playground/cssom/index.html
@@ -88,7 +88,8 @@ http://creativecommons.org/publicdomain/zero/1.0/
 (function() {
     setTimeout(
             function () {
-                var flow = document.webkitGetNamedFlows().namedItem("article");
+                var flows = document.webkitGetNamedFlows()
+                var flow = flows.namedItem("article");
 
                 flow.addEventListener("regionLayoutUpdate", function(e) {
                     var art, div;
@@ -97,8 +98,8 @@ http://creativecommons.org/publicdomain/zero/1.0/
                         div.className = "myregions";
                         art = document.getElementById("art");
                         art.appendChild(div);
-                        if (CSSRegions) {
-                            CSSRegions.addRegionToNamedFlow("article", div);
+                        if (CSSRegions) {   
+                            flow.regions.push(div)
                             CSSRegions.doLayout();
                         }
                     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -7,7 +7,6 @@ module('CSS Regions polyfill')
 
 test("polyfill exists", function(){
     ok(CSSRegions)
-
 })
 
 test('has doLayout method', function(){
@@ -16,4 +15,126 @@ test('has doLayout method', function(){
 
 test('has namedFlows method', function(){
     ok(typeof CSSRegions.namedFlows, 'has named flows')
+}) 
+                     
+
+var testCollection
+
+module("Collection", {
+    setup: function(){
+     var array = [
+        {
+            name: "oprea",
+            value: 1
+        },
+        {
+            name: "costel",
+            value: 2
+        }
+     ]
+
+     testCollection = new CSSRegions.Collection(array, "name")
+    }, 
+    
+    teardown: function(){
+       testCollection = null
+    }
+    
+})            
+
+test('Collection constructor exists', function(){
+    equal(typeof CSSRegions.Collection, 'function', 'Collection is defined')
+})
+
+test('Collection has length', function(){
+    equal(testCollection.length, 2, 'has 2 items')
+})
+
+test('Collection items can be accessed by index', function(){
+    ok(testCollection[0], 'first item is defined')
+    equal(testCollection[0].name, 'oprea', 'first item is defined')
+})
+
+test('Collection has item() method', function(){
+    equal(typeof testCollection.item, 'function', 'item() is defined as function')
+    ok(testCollection.item(0), 'first item exists')
+    equal(testCollection.item(0).name, 'oprea', 'first item is oprea')
+    equal(testCollection.item(1).name, 'costel', 'second item is costel')
+})
+
+test('Collection has namedIdem() method', function(){
+    equal(typeof testCollection.namedItem, 'function', 'namedIdem() is defined as function')
+    ok(testCollection.namedItem('oprea'), 'first item exists')
+    equal(testCollection.namedItem('oprea').name, 'oprea', 'first item is oprea')
+    equal(testCollection.namedItem('costel').name, 'costel', 'second item is costel')
+})
+
+module('CSSOM', {
+    setup: function(){
+        var style = document.createElement('style')
+        style.id = 'testStyle'
+        style.innerHTML = '#testSource { flow-into: article } .region{ flow-from: article; width: 100px; height: 20px; }'
+
+        var el = document.createElement('div') 
+        el.id = 'testHTML'
+        el.innerHTML = "<div id=\"source\">\
+            <p>Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet.</p>\
+        </div>\
+        <div class=\"region\"></div>\
+        <div class=\"region\"></div>"
+        
+        document.getElementsByTagName('body')[0].appendChild(el)
+        document.getElementsByTagName('head')[0].appendChild(style)        
+    },
+    teardown: function(){  
+        var style = document.getElementById('testStyle')
+        style.parentNode.removeChild(style)
+        
+        var testEl = document.getElementById('testHTML')
+        testEl.parentNode.removeChild(testEl)
+    }
+})
+
+test('NamedFlow exists', function(){
+    var nf = new CSSRegions.NamedFlow()
+    
+    ok(nf, 'Named flow exists')
+})
+
+test('NamedFlow has name', function(){
+    var flowName = 'myFlow',
+        nf = new CSSRegions.NamedFlow(flowName)
+        
+    equal(nf.name, flowName, 'Named flow has name')
+})
+
+test('NamedFlow has overset property', function(){
+    var nf = new CSSRegions.NamedFlow('myFlow')
+    
+    strictEqual(nf.overset, true, 'Has overset property set to "true" if no region chain')
+}) 
+      
+
+
+test('NamedFlow has regions', function(){
+    var nf = new CSSRegions.NamedFlow('myFlow', ['#source'], ['.region'])
+
+    equal(typeof nf.getRegions, 'function', 'getRegions() is defined as function')
+    // equal(nf.getRegions(), Array.prototype.slice.call(document.querySelectorAll('.region'), 0), 'has 2 regions')
+    equal(nf.getRegions().length, 2, 'has 2 regions')
+}) 
+
+test('NamedFlow has contentNodes', function(){
+    var nf = new CSSRegions.NamedFlow('myFlow', ['#source'], ['.region'])
+    
+    ok(nf.contentNodes, 'contentNodes is defined')
+    equal(nf.contentNodes.length, 1, 'has one content node')
+}) 
+
+test('document has getNamedFlows method', function(){
+    equal(typeof document.getNamedFlows, 'function', 'getNamedFlows() is defined as function')
+})
+
+test('document has getFlowByName method', function(){
+    equal(typeof document.getFlowByName, 'function', 'getFlowByName() is defined as function')
 })

--- a/test/tests.js
+++ b/test/tests.js
@@ -73,7 +73,7 @@ module('CSSOM', {
     setup: function(){
         var style = document.createElement('style')
         style.id = 'testStyle'
-        style.innerHTML = '#testSource { flow-into: article } .region{ flow-from: article; width: 100px; height: 20px; }'
+        style.innerHTML = '#testSource { flow-into: myFlow } .region{ flow-from: myFlow; width: 100px; height: 20px; }'
 
         var el = document.createElement('div') 
         el.id = 'testHTML'
@@ -113,8 +113,6 @@ test('NamedFlow has overset property', function(){
     
     strictEqual(nf.overset, true, 'Has overset property set to "true" if no region chain')
 }) 
-      
-
 
 test('NamedFlow has regions', function(){
     var nf = new CSSRegions.NamedFlow('myFlow', ['#source'], ['.region'])
@@ -132,9 +130,20 @@ test('NamedFlow has contentNodes', function(){
 }) 
 
 test('document has getNamedFlows method', function(){
+    CSSRegions.init()  
+    
     equal(typeof document.getNamedFlows, 'function', 'getNamedFlows() is defined as function')
+    equal(document.getNamedFlows().length, 1, 'one named flow exists')
+    ok(document.getNamedFlows().item(0), 'named flow can be accessed by item()')
+    ok(document.getNamedFlows().namedItem('myFlow'), 'named flow can be accessed by namedItem()')
+    ok(document.getNamedFlows()[0], 'named flow can be accessed by index')
+    equal(document.getNamedFlows()[0].name, 'myFlow', 'named flow has name')
 })
 
 test('document has getFlowByName method', function(){
+    CSSRegions.init()
+    
     equal(typeof document.getFlowByName, 'function', 'getFlowByName() is defined as function')
+    ok(document.getFlowByName('myFlow'), 'named flow can be accessed by name')
+    equal(document.getFlowByName('myFlow').name, 'myFlow', 'named flow has name')
 })


### PR DESCRIPTION
Improved Regions CSSOM and refactoring.

Overview:
- NamedFlow objects are now first class citizens used throughout the polyfill logic
- NamedFlow.getNamedFlows() now returns a Collection
- Global CSSOM methods are exposed in one place
- Unit tests for new functionality

Regions CSSOM coverage:
- document.getNamedFlows() -> Collection of NamedFlows
  - .item()
  - .namedItem()
- document.getFlowByName()
- NamedFlow.getRegions()
- NamedFlow.contentNodes
- NamedFlow.name
- NamedFlow.overset
- regionLayoutUpdate event

Tested on Chrome (no regions) / Firefox / Safari and iOS

Upcoming refactoring: 
- move layout logic inside the NamedFlow object so it can react automatically when regions and contentNodes are manipulated.
- transparent support for vendor prefixes
