### PR TITLE
Prefix

### DIFF
--- a/playground/src/cssregions.js
+++ b/playground/src/cssregions.js
@@ -526,7 +526,6 @@ window.CSSRegions = function(scope) {
         // Polyfill necesary objects/methods on the document/window as specified by the CSS Regions spec
         exposeGlobalOM: function(){
             document['getNamedFlows'] = document['webkitGetNamedFlows'] = this.getNamedFlows.bind(this)
-            document['getFlowByName'] = document['webkitGetFlowByName'] = this.getFlowByName.bind(this)
         },
           
         /*
@@ -537,13 +536,6 @@ window.CSSRegions = function(scope) {
             return this.namedFlowCollection
         },
           
-        /*
-            Returns a NamedFlow instance by its name or null if it does not exist
-        */
-        getFlowByName: function(name){         
-            return this.namedFlowCollection.namedItem(name) || null
-        },
-        
         "NamedFlow": NamedFlow,
         "Collection": Collection
     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -140,14 +140,6 @@ test('document has getNamedFlows method', function(){
     equal(document.getNamedFlows()[0].name, 'myFlow', 'named flow has name')
 })
 
-test('document has getFlowByName method', function(){
-    CSSRegions.init()
-    
-    equal(typeof document.getFlowByName, 'function', 'getFlowByName() is defined as function')
-    ok(document.getFlowByName('myFlow'), 'named flow can be accessed by name')
-    equal(document.getFlowByName('myFlow').name, 'myFlow', 'named flow has name')
-})
-
 // Prefix support for demos built using only vendor-specific code.
 // This is bad and we should feel bad.
 // TODO: update regions demos/code to use vendor agnostic code.
@@ -166,7 +158,7 @@ asyncTest('NamedFlow throws regionLayoutUpdate event', function(){
     
     CSSRegions.init()  
     
-    var nf = document.getFlowByName('myFlow'),
+    var nf = document.getNamedFlows().namedItem('myFlow'),
         region1 = document.querySelector('.region');
         
     nf.addEventListener('regionLayoutUpdate', function(e){
@@ -177,5 +169,4 @@ asyncTest('NamedFlow throws regionLayoutUpdate event', function(){
     // force a relayout
     region1.style = "width: 50px"
     CSSRegions.doLayout()
-
 })

--- a/test/tests.js
+++ b/test/tests.js
@@ -148,6 +148,18 @@ test('document has getFlowByName method', function(){
     equal(document.getFlowByName('myFlow').name, 'myFlow', 'named flow has name')
 })
 
+// Prefix support for demos built using only vendor-specific code.
+// This is bad and we should feel bad.
+// TODO: update regions demos/code to use vendor agnostic code.
+test('Smoke test prefix support', function(){
+    CSSRegions.init()  
+    
+    equal(typeof document.webkitGetNamedFlows, 'function', 'webkitGetNamedFlows() is defined as function')
+
+    var nf = document.webkitGetNamedFlows().namedItem('myFlow')
+    ok(nf, 'named flow can be accessed by webkitGetNamedFlows()')
+})
+
 asyncTest('NamedFlow throws regionLayoutUpdate event', function(){
     // expect one assertion
     expect(1)              
@@ -159,7 +171,7 @@ asyncTest('NamedFlow throws regionLayoutUpdate event', function(){
         
     nf.addEventListener('regionLayoutUpdate', function(e){
         start()
-        equal(e.target.name, 'myFlow')
+        equal(e.target.name, 'myFlow') 
     })  
     
     // force a relayout


### PR DESCRIPTION
support for prefixed .getNamedFlows()
dropped support for .getFlowByName()
